### PR TITLE
implemented fix for macOS/Fusion recursive error

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,11 @@
 Vagrant.configure("2") do |config|
   # define system 
   config.vm.box = "bento/ubuntu-18.04"
+  if Vagrant::Util::Platform.darwin?
+    config.vm.provider "vmware_desktop" do |v|
+      v.clone_directory = "~/Documents/Virtual\ Machines.localized/"
+    end
+  end
 
   # Copy repo
   config.vm.provision "file", 


### PR DESCRIPTION
# issue
- see https://github.com/NodyHub/k8s-ctf-rocks/issues/1

# analysis
Default directory for clones is `./.vagrant` on for `vmware_fusion` provider so scp was trying to copy the .vmdk to the VM itself due to the following directive in Vagrantfile:
```
config.vm.provision "file", 
    source: ".", 
	destination: "/home/vagrant/"
```

# solution
Added condition to store vmdk in default Fusion folder on macOS using a filter on the host OS and on the used provider.

Thanks for the cool CTF!